### PR TITLE
Various Bug Fixes

### DIFF
--- a/BeatSaberPlaylistsLib/BeatSaberPlaylistsLib.manifest
+++ b/BeatSaberPlaylistsLib/BeatSaberPlaylistsLib.manifest
@@ -3,7 +3,7 @@
   "id": "BeatSaberPlaylistsLib",
   "name": "BeatSaberPlaylistsLib",
   "author": "Zingabopp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A playlist loading library.",
   "gameVersion": "1.14.0",
   "files": [

--- a/BeatSaberPlaylistsLib/PlaylistManager.cs
+++ b/BeatSaberPlaylistsLib/PlaylistManager.cs
@@ -356,6 +356,13 @@ namespace BeatSaberPlaylistsLib
             }
             if (includeChildren)
             {
+                // Delete any folders that are since deleted to save an exception
+                List<PlaylistManager> managersToDelete = GetChildManagers().Where((childManager) => !Directory.Exists(childManager.PlaylistPath)).ToList();
+                foreach (var manager in managersToDelete)
+                {
+                    ChildManagers.Remove(manager);
+                }
+
                 foreach (var manager in GetChildManagers())
                 {
                     manager.LoadAllPlaylists(loadedPlaylists, includeChildren, erroredPlaylists, exceptions);

--- a/BeatSaberPlaylistsLib/Types/Playlist.BeatSaber.cs
+++ b/BeatSaberPlaylistsLib/Types/Playlist.BeatSaber.cs
@@ -143,7 +143,7 @@ namespace BeatSaberPlaylistsLib.Types
         /// <summary>
         /// BeatmapLevelPack ID.
         /// </summary>
-        public string packID => BeatSaber.CustomLevelLoader.kCustomLevelPackPrefixId + Title;
+        public string packID => BeatSaber.CustomLevelLoader.kCustomLevelPackPrefixId + playlistID;
 
         /// <summary>
         /// BeatmapLevelPack Name, same as name of the collection.
@@ -163,11 +163,19 @@ namespace BeatSaberPlaylistsLib.Types
         /// Returns a new array of the songs in this playlist.
         /// </summary>
 #pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
-        BeatSaber.IPreviewBeatmapLevel[] BeatSaber.IBeatmapLevelCollection.beatmapLevels
-            => Songs
-            .Where(s => s.PreviewBeatmapLevel != null)
-            .Select(s => s)
-            .ToArray();
+        BeatSaber.IPreviewBeatmapLevel[] BeatSaber.IBeatmapLevelCollection.beatmapLevels {
+            get
+            {
+                Songs.ForEach(delegate(T s) {
+                    if (s is PlaylistSong playlistSong)
+                    {
+                        playlistSong.RefreshFromSongCore();
+                    }
+                });
+                return Songs.Where(s => s.PreviewBeatmapLevel != null).Select(s => s).ToArray();
+            }
+        }
+
 #pragma warning restore CS8619 // Nullability of reference types in value doesn't match target type.
         /// <inheritdoc/>
         public IPlaylistSong? Add(BeatSaber.IPreviewBeatmapLevel beatmap)

--- a/BeatSaberPlaylistsLib/Types/Playlist.cs
+++ b/BeatSaberPlaylistsLib/Types/Playlist.cs
@@ -27,6 +27,10 @@ namespace BeatSaberPlaylistsLib.Types
         public virtual string Filename { get; set; } = "";
         /// <inheritdoc/>
         public string? SuggestedExtension { get; set; }
+        /// <summary>
+        /// Unique identifier for the playlist, used for distinguishing between duplicates.
+        /// </summary>
+        public Guid playlistID { get; } = Guid.NewGuid();
         /// <inheritdoc/>
         public bool AllowDuplicates
         {


### PR DESCRIPTION
- PlaylistManager.LoadAllPlaylists(): We now check for and delete folders that now no longer exist. This saves a DirectoryNotFoundException if someone messes with folders while the lib is running
- Playlist: Added GUID and appended GUID to packID. Justification: SongBrowser uses packIDs to select the previously selected playlist. We used to just append playlist name to packID but that has the problem of having 2 playlists with the same name causing trouble. A unique identifier should fix that.
- Playlist: Refresh every PlaylistSong with SongCore before returning beatmapLevels. Justification: If some song is deleted through SongBrowser or externally, it persists in the playlist. Selecting it causes a NullReferenceException. This should fix it.