### PR TITLE
Version Bump 1.3.0

### DIFF
--- a/BeatSaberPlaylistsLib.BeatSaber/BeatSaberPlaylistsLib.xml
+++ b/BeatSaberPlaylistsLib.BeatSaber/BeatSaberPlaylistsLib.xml
@@ -1652,6 +1652,11 @@
         <member name="P:BeatSaberPlaylistsLib.Types.Playlist.Sprite">
             <inheritdoc/>
         </member>
+        <member name="M:BeatSaberPlaylistsLib.Types.Playlist.RaiseCoverImageChangedForDefaultCover">
+            <summary>
+            Raises cover image changed if we are using default image. Called when we change the title in a Playlist UI.
+            </summary>
+        </member>
         <member name="E:BeatSaberPlaylistsLib.Types.Playlist.PlaylistChanged">
             <inheritdoc/>
         </member>
@@ -1762,7 +1767,12 @@
         </member>
         <member name="P:BeatSaberPlaylistsLib.Types.Playlist`1.IBeatmapLevelCollection#beatmapLevels">
             <summary>
-            Returns a new array of the songs in this playlist.
+            Returns a new array of IPreviewBeatmapLevels in this playlist.
+            </summary>
+        </member>
+        <member name="P:BeatSaberPlaylistsLib.Types.Playlist`1.BeatmapLevels">
+            <summary>
+            Returns a new array of PlaylistSongs (cast as IPreviewBeatmapLevels) in this playlist.
             </summary>
         </member>
         <member name="M:BeatSaberPlaylistsLib.Types.Playlist`1.Add(IPreviewBeatmapLevel)">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Authors>Zingabopp</Authors>
     
-    <Version>1.2.2</Version>
+    <Version>1.3.0</Version>
     <GameVersion>1.14.0</GameVersion>
     
     <Copyright>Copyright © Zingabopp 2021</Copyright>

--- a/src/Types/Playlist.BeatSaber.cs
+++ b/src/Types/Playlist.BeatSaber.cs
@@ -98,7 +98,7 @@ namespace BeatSaberPlaylistsLib.Types
                 BeatSaber.SharedCoroutineStarter.instance.StartCoroutine(SpriteLoadCoroutine());
         }
 
-        #region IDeferredSpriteLoad
+#region IDeferredSpriteLoad
 
         /// <inheritdoc/>
         public event EventHandler? SpriteLoaded;
@@ -120,6 +120,18 @@ namespace BeatSaberPlaylistsLib.Types
                     QueueLoadSprite(this);
                 }
                 return _sprite;
+            }
+        }
+
+        /// <summary>
+        /// Raises cover image changed if we are using default image. Called when we change the title in a Playlist UI.
+        /// </summary>
+        public void RaiseCoverImageChangedForDefaultCover()
+        {
+            if (!HasCover)
+            {
+                RaiseCoverImageChanged();
+                _ = Sprite;
             }
         }
 
@@ -160,13 +172,29 @@ namespace BeatSaberPlaylistsLib.Types
         /// </summary>
         BeatSaber.IBeatmapLevelCollection BeatSaber.IAnnotatedBeatmapLevelCollection.beatmapLevelCollection => this;
         /// <summary>
-        /// Returns a new array of the songs in this playlist.
+        /// Returns a new array of IPreviewBeatmapLevels in this playlist.
         /// </summary>
 #pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
         BeatSaber.IPreviewBeatmapLevel[] BeatSaber.IBeatmapLevelCollection.beatmapLevels {
             get
             {
                 Songs.ForEach(delegate(T s) {
+                    if (s is PlaylistSong playlistSong)
+                    {
+                        playlistSong.RefreshFromSongCore();
+                    }
+                });
+                return Songs.Where(s => s.PreviewBeatmapLevel != null).Select(s => s.PreviewBeatmapLevel).ToArray();
+            }
+        }
+        /// <summary>
+        /// Returns a new array of PlaylistSongs (cast as IPreviewBeatmapLevels) in this playlist.
+        /// </summary>
+        public BeatSaber.IPreviewBeatmapLevel[] BeatmapLevels
+        {
+            get
+            {
+                Songs.ForEach(delegate (T s) {
                     if (s is PlaylistSong playlistSong)
                     {
                         playlistSong.RefreshFromSongCore();

--- a/src/Types/Playlist.BeatSaber.cs
+++ b/src/Types/Playlist.BeatSaber.cs
@@ -200,7 +200,7 @@ namespace BeatSaberPlaylistsLib.Types
                         playlistSong.RefreshFromSongCore();
                     }
                 });
-                return Songs.Where(s => s.PreviewBeatmapLevel != null).Select(s => s).ToArray();
+                return Songs.Where(s => s.PreviewBeatmapLevel != null).ToArray();
             }
         }
 
@@ -227,7 +227,7 @@ namespace BeatSaberPlaylistsLib.Types
                 return null;
 
             Difficulty difficulty = new Difficulty();
-            difficulty.Name = Difficulty.DifficultyValueToString((int)beatmap.difficulty);
+            difficulty.BeatmapDifficulty = beatmap.difficulty;
             difficulty.Characteristic = beatmap.parentDifficultyBeatmapSet.beatmapCharacteristic.serializedName;
             IPlaylistSong? song = Add(new T()
             {

--- a/src/Utilities.cs
+++ b/src/Utilities.cs
@@ -193,8 +193,12 @@ namespace BeatSaberPlaylistsLib
         {
             using Stream? stream = GetDefaultImageStream();
             //Console.WriteLine($"Drawing string {playlist.Title}");
-            string firstLetterOnly = string.Join("", (from word in playlist.Title.Split() select word[0]));
-            Image img = ImageUtilities.DrawString(firstLetterOnly, Image.FromStream(stream), defaultDrawSettings);
+            string title = playlist.Title;
+            if (title.Length > 110)
+            {
+                title = string.Join("", (from word in playlist.Title.Split() select word[0]));
+            }
+            Image img = ImageUtilities.DrawString(title, Image.FromStream(stream), defaultDrawSettings);
             MemoryStream ms = new MemoryStream();
             img.Save(ms, ImageFormat.Png);
             return ms;


### PR DESCRIPTION
- The base game get_beatmapLevels now returns the base game types, instead BeatmapLevels property part of Playlists returns the loaded PlaylistSongs as beatmapLevels. Requested by Kyle for more transparency.
- RaiseCoverImageChangedForDefaultCover is called by PlaylistManager when the title of a playlist is changed and the cover image is default (so the image also updates).
- Cover image text algorithm is now improved and allows for full words if they fit. Short forms are only added when we are above the generous 110 character limit that fits in the image.