### PR TITLE
Next Version

### DIFF
--- a/.github/workflows/BuildMaster.yml
+++ b/.github/workflows/BuildMaster.yml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: matrix.configuration == 'Release-BeatSaber'
       with:
-        name: ${{ steps.Build.outputs.filename }}
+        name: 'BeatSaberPlaylistsLib_BS'
         path: ${{ steps.Build.outputs.artifactpath }}
     - name: Upload ${{ matrix.configuration }} Nuget
       uses: actions/upload-artifact@v2

--- a/BeatSaberPlaylistsLib.BeatSaber/BeatSaberPlaylistsLib.xml
+++ b/BeatSaberPlaylistsLib.BeatSaber/BeatSaberPlaylistsLib.xml
@@ -194,6 +194,11 @@
             Allow duplicate songs in the playlist.
             </summary>
         </member>
+        <member name="P:BeatSaberPlaylistsLib.Types.IPlaylist.ReadOnly">
+            <summary>
+            Disable editing of playlist.
+            </summary>
+        </member>
         <member name="M:BeatSaberPlaylistsLib.Types.IPlaylist.Add(BeatSaberPlaylistsLib.Types.ISong)">
             <summary>
             Adds the <see cref="T:BeatSaberPlaylistsLib.Types.ISong"/> to the playlist. 
@@ -417,7 +422,7 @@
         <member name="P:BeatSaberPlaylistsLib.Types.Playlist.AllowDuplicates">
             <inheritdoc/>
         </member>
-        <member name="P:BeatSaberPlaylistsLib.Types.Playlist.IsReadOnly">
+        <member name="P:BeatSaberPlaylistsLib.Types.Playlist.ReadOnly">
             <inheritdoc/>
         </member>
         <member name="P:BeatSaberPlaylistsLib.Types.Playlist.HasCover">
@@ -526,6 +531,9 @@
             <inheritdoc/>
         </member>
         <member name="P:BeatSaberPlaylistsLib.Types.Playlist`1.Count">
+            <inheritdoc/>
+        </member>
+        <member name="P:BeatSaberPlaylistsLib.Types.Playlist`1.IsReadOnly">
             <inheritdoc/>
         </member>
         <member name="M:BeatSaberPlaylistsLib.Types.Playlist`1.CreateFrom(BeatSaberPlaylistsLib.Types.ISong)">
@@ -1448,9 +1456,6 @@
             <summary>
             Raw data for the cover image.
             </summary>
-        </member>
-        <member name="P:BeatSaberPlaylistsLib.Legacy.LegacyPlaylist.IsReadOnly">
-            <inheritdoc/>
         </member>
         <member name="P:BeatSaberPlaylistsLib.Legacy.LegacyPlaylist.HasCover">
             <inheritdoc/>

--- a/BeatSaberPlaylistsLib.BeatSaber/BeatSaberPlaylistsLib.xml
+++ b/BeatSaberPlaylistsLib.BeatSaber/BeatSaberPlaylistsLib.xml
@@ -196,7 +196,7 @@
         </member>
         <member name="P:BeatSaberPlaylistsLib.Types.IPlaylist.ReadOnly">
             <summary>
-            Disable editing of playlist.
+            Disable editing of playlist. This has to be handled by the UI itself, the lib does not handle it.
             </summary>
         </member>
         <member name="M:BeatSaberPlaylistsLib.Types.IPlaylist.Add(BeatSaberPlaylistsLib.Types.ISong)">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Authors>Zingabopp</Authors>
     
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <GameVersion>1.16.0</GameVersion>
     
     <Copyright>Copyright © Zingabopp 2021</Copyright>

--- a/Shared/Legacy/LegacyPlaylist.cs
+++ b/Shared/Legacy/LegacyPlaylist.cs
@@ -169,9 +169,6 @@ namespace BeatSaberPlaylistsLib.Legacy
         }
 
         ///<inheritdoc/>
-        public override bool IsReadOnly => false;
-
-        ///<inheritdoc/>
         public override bool HasCover => CoverData != null && CoverData.Length > 0;
 
         ///<inheritdoc/>

--- a/Shared/PlaylistManager.cs
+++ b/Shared/PlaylistManager.cs
@@ -805,8 +805,44 @@ namespace BeatSaberPlaylistsLib
             if (playlist.SuggestedExtension != null && playlistHandler.GetSupportedExtensions().Contains(playlist.SuggestedExtension))
                 extension = playlist.SuggestedExtension;
             string fileName = playlist.Filename;
+
             if (string.IsNullOrEmpty(fileName))
-                throw new ArgumentException(nameof(playlist), "Playlist's filename is null or empty.");
+            {
+                // Generate Name
+                fileName = string.Join("_", playlist.Title
+                    .Replace("/", "")
+                    .Replace("\\", "")
+                    .Replace(".", "")
+                    .Replace(":", "")
+                    .Replace("*", "")
+                    .Replace("?", "")
+                    .Replace("\"", "")
+                    .Replace("<", "")
+                    .Replace(">", "")
+                    .Replace("|", "")
+                    .Split());
+                if (string.IsNullOrEmpty(fileName))
+                {
+                    fileName = "playlist";
+                }
+
+                string path = Path.Combine(PlaylistPath, fileName + "." + extension);
+                string originalPath = Path.Combine(PlaylistPath, fileName);
+                int dupNum = 0;
+                while (File.Exists(path))
+                {
+                    dupNum++;
+                    path = originalPath + $"({dupNum}).{extension}";
+                }
+
+                if (dupNum != 0)
+                {
+                    fileName += $"({dupNum})";
+                }
+
+                playlist.Filename = fileName;
+            }
+
             playlistHandler.SerializeToFile(playlist, Path.Combine(PlaylistPath, fileName + "." + extension));
             RegisterPlaylist(playlist, false);
             if (removeFromChanged)

--- a/Shared/PlaylistManager.cs
+++ b/Shared/PlaylistManager.cs
@@ -809,18 +809,7 @@ namespace BeatSaberPlaylistsLib
             if (string.IsNullOrEmpty(fileName))
             {
                 // Generate Name
-                fileName = string.Join("_", playlist.Title
-                    .Replace("/", "")
-                    .Replace("\\", "")
-                    .Replace(".", "")
-                    .Replace(":", "")
-                    .Replace("*", "")
-                    .Replace("?", "")
-                    .Replace("\"", "")
-                    .Replace("<", "")
-                    .Replace(">", "")
-                    .Replace("|", "")
-                    .Split());
+                fileName = string.Join("_", string.Join("", playlist.Title.Split(Path.GetInvalidFileNameChars(), StringSplitOptions.RemoveEmptyEntries)).Split());
                 if (string.IsNullOrEmpty(fileName))
                 {
                     fileName = "playlist";

--- a/Shared/Shared.projitems
+++ b/Shared/Shared.projitems
@@ -35,6 +35,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utilities.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)Icons\FolderIcon.png" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Icons\FolderIcon.png" />
   </ItemGroup>
 </Project>

--- a/Shared/Types/IPlaylist.cs
+++ b/Shared/Types/IPlaylist.cs
@@ -59,6 +59,10 @@ namespace BeatSaberPlaylistsLib.Types
         /// </summary>
         bool AllowDuplicates { get; set; }
         /// <summary>
+        /// Disable editing of playlist.
+        /// </summary>
+        bool ReadOnly { get; set; }
+        /// <summary>
         /// Adds the <see cref="ISong"/> to the playlist. 
         /// Does nothing if <see cref="AllowDuplicates"/> is false and the song is already in the playlist. 
         /// Converts the <see cref="ISong"/> if needed.

--- a/Shared/Types/IPlaylist.cs
+++ b/Shared/Types/IPlaylist.cs
@@ -59,7 +59,7 @@ namespace BeatSaberPlaylistsLib.Types
         /// </summary>
         bool AllowDuplicates { get; set; }
         /// <summary>
-        /// Disable editing of playlist.
+        /// Disable editing of playlist. This has to be handled by the UI itself, the lib does not handle it.
         /// </summary>
         bool ReadOnly { get; set; }
         /// <summary>

--- a/Shared/Types/Playlist.cs
+++ b/Shared/Types/Playlist.cs
@@ -162,7 +162,7 @@ namespace BeatSaberPlaylistsLib.Types
         public int Count => Songs.Count;
 
         /// <inheritdoc/>
-        public virtual bool IsReadOnly => false;
+        public virtual bool IsReadOnly => ReadOnly;
 
         /// <summary>
         /// Creates a new <see cref="IPlaylistSong"/> of type <typeparamref name="T"/> from the given <paramref name="song"/>.

--- a/Shared/Types/Playlist.cs
+++ b/Shared/Types/Playlist.cs
@@ -44,7 +44,16 @@ namespace BeatSaberPlaylistsLib.Types
         }
 
         /// <inheritdoc/>
-        public virtual bool IsReadOnly => false;
+        public bool ReadOnly
+        {
+            get
+            {
+                if (TryGetCustomData("ReadOnly", out object? returnVal) && returnVal is bool boolVal)
+                    return boolVal;
+                return false;
+            }
+            set => SetCustomData("ReadOnly", value);
+        }
 
         /// <inheritdoc/>
         public abstract bool HasCover { get; }
@@ -151,6 +160,9 @@ namespace BeatSaberPlaylistsLib.Types
 
         /// <inheritdoc/>
         public int Count => Songs.Count;
+
+        /// <inheritdoc/>
+        public virtual bool IsReadOnly => false;
 
         /// <summary>
         /// Creates a new <see cref="IPlaylistSong"/> of type <typeparamref name="T"/> from the given <paramref name="song"/>.


### PR DESCRIPTION
- Adds playlist file name generation (if there is no filename). Reasoning: PlaylistManager and MorePlaylists use the same copy pasted code to do this, better to centralize it here
- Added ReadOnly bool in playlist to enable that feature in PlaylistManager
- Static artifact name for CI