### PR TITLE
Marked various classes as serializable

### DIFF
--- a/Shared/Blist/BlistPlaylistSong.cs
+++ b/Shared/Blist/BlistPlaylistSong.cs
@@ -11,6 +11,7 @@ namespace BeatSaberPlaylistsLib.Blist
     /// An <see cref="IPlaylistSong"/> that can be serialized in a <see cref="BlistPlaylist"/>.
     /// </summary>
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+    [Serializable]
     public class BlistPlaylistSong : JSONPlaylistSong
     {
         /// <summary>

--- a/Shared/Legacy/LegacyPlaylistSong.cs
+++ b/Shared/Legacy/LegacyPlaylistSong.cs
@@ -9,6 +9,7 @@ namespace BeatSaberPlaylistsLib.Legacy
     /// An <see cref="IPlaylistSong"/> that can be serialized in a <see cref="LegacyPlaylist"/>.
     /// </summary>
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+    [Serializable]
     public class LegacyPlaylistSong : JSONPlaylistSong, IEquatable<IPlaylistSong>
     {
         /// <summary>

--- a/Shared/Types/Difficulty.cs
+++ b/Shared/Types/Difficulty.cs
@@ -9,6 +9,7 @@ namespace BeatSaberPlaylistsLib.Types
     /// <summary>
     /// A beatmap difficulty
     /// </summary>
+    [Serializable]
     public partial struct Difficulty
     {
         private const int kEasyValue = 0;

--- a/Shared/Types/JSONPlaylistSong.cs
+++ b/Shared/Types/JSONPlaylistSong.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,6 +10,7 @@ namespace BeatSaberPlaylistsLib.Types
     /// <summary>
     /// An abstract class for a playlist song in a JSON playlist file.
     /// </summary>
+    [Serializable]
     public abstract class JSONPlaylistSong : PlaylistSong
     {
         /// <summary>

--- a/Shared/Types/PlaylistSong.cs
+++ b/Shared/Types/PlaylistSong.cs
@@ -6,6 +6,7 @@ namespace BeatSaberPlaylistsLib.Types
     /// <summary>
     /// Base class for a PlaylistSong.
     /// </summary>
+    [Serializable]
     public abstract partial class PlaylistSong : IPlaylistSong
     {
         /// <summary>


### PR DESCRIPTION
Reasoning: When copying to clipboard in PlaylistManagerDesktop, it requires these classes to be marked as serializable so the PlaylistSong can be saved to the clipboard