### PR TITLE
Optimized Cover Sprite Generation

### DIFF
--- a/BeatSaberPlaylistsLib.BeatSaber/BeatSaberPlaylistsLib.xml
+++ b/BeatSaberPlaylistsLib.BeatSaber/BeatSaberPlaylistsLib.xml
@@ -1155,11 +1155,11 @@
             <param name="returnDefaultOnFail"></param>
             <returns></returns>
         </member>
-        <member name="M:BeatSaberPlaylistsLib.Utilities.GetStreamFromSprite(UnityEngine.Sprite)">
+        <member name="M:BeatSaberPlaylistsLib.Utilities.GetStreamFromBeatmap(IPreviewBeatmapLevel)">
             <summary>
             Gets a <see cref="T:System.IO.Stream"/> from a <see cref="T:UnityEngine.Sprite"/>
             </summary>
-            <param name="sprite"></param>
+            <param name="previewBeatmapLevel"></param>
             <returns></returns>
         </member>
         <member name="M:BeatSaberPlaylistsLib.Utilities.DownscaleImage(System.IO.Stream,System.Int32)">

--- a/BeatSaberPlaylistsLib.BeatSaber/Types/Playlist.BeatSaber.cs
+++ b/BeatSaberPlaylistsLib.BeatSaber/Types/Playlist.BeatSaber.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using static BeatSaber::SliderController.Pool;
+using IBeatmapLevelCollection = BeatSaber::IBeatmapLevelCollection;
 
 namespace BeatSaberPlaylistsLib.Types
 {
@@ -317,33 +318,34 @@ namespace BeatSaberPlaylistsLib.Types
             }
 
             var ms = new MemoryStream();
+            var beatmapLevels = ((IBeatmapLevelCollection) this).beatmapLevels;
 
-            if (BeatmapLevels.Length == 1)
+            if (beatmapLevels.Count == 1)
             {
-                using var coverStream = Utilities.GetStreamFromSprite(await BeatmapLevels[0].GetCoverImageAsync(CancellationToken.None));
+                using var coverStream = Utilities.GetStreamFromBeatmap(beatmapLevels[0]);
                 if (coverStream != null) await coverStream.CopyToAsync(ms);
             }
-            else if (BeatmapLevels.Length == 2)
+            else if (beatmapLevels.Count == 2)
             {
-                using var imageStream1 = Utilities.GetStreamFromSprite(await BeatmapLevels[0].GetCoverImageAsync(CancellationToken.None));
-                using var imageStream2 = Utilities.GetStreamFromSprite(await BeatmapLevels[1].GetCoverImageAsync(CancellationToken.None));
+                using var imageStream1 = Utilities.GetStreamFromBeatmap(beatmapLevels[0]);
+                using var imageStream2 = Utilities.GetStreamFromBeatmap(beatmapLevels[1]);
                 using var coverStream = await ImageUtilities.GenerateCollage(imageStream1 ?? Stream.Null, imageStream2 ?? Stream.Null);
                 await coverStream.CopyToAsync(ms);
             }
-            else if (BeatmapLevels.Length == 3)
+            else if (beatmapLevels.Count == 3)
             {
-                using var imageStream1 = Utilities.GetStreamFromSprite(await BeatmapLevels[0].GetCoverImageAsync(CancellationToken.None));
-                using var imageStream2 = Utilities.GetStreamFromSprite(await BeatmapLevels[1].GetCoverImageAsync(CancellationToken.None));
-                using var imageStream3 = Utilities.GetStreamFromSprite(await BeatmapLevels[2].GetCoverImageAsync(CancellationToken.None));
+                using var imageStream1 = Utilities.GetStreamFromBeatmap(beatmapLevels[0]);
+                using var imageStream2 = Utilities.GetStreamFromBeatmap(beatmapLevels[1]);
+                using var imageStream3 = Utilities.GetStreamFromBeatmap(beatmapLevels[2]);
                 using var coverStream = await ImageUtilities.GenerateCollage(imageStream1 ?? Stream.Null, imageStream2 ?? Stream.Null, imageStream3 ?? Stream.Null);
                 await coverStream.CopyToAsync(ms);
             }
             else
             {
-                using var imageStream1 = Utilities.GetStreamFromSprite(await BeatmapLevels[0].GetCoverImageAsync(CancellationToken.None));
-                using var imageStream2 = Utilities.GetStreamFromSprite(await BeatmapLevels[1].GetCoverImageAsync(CancellationToken.None));
-                using var imageStream3 = Utilities.GetStreamFromSprite(await BeatmapLevels[2].GetCoverImageAsync(CancellationToken.None));
-                using var imageStream4 = Utilities.GetStreamFromSprite(await BeatmapLevels[3].GetCoverImageAsync(CancellationToken.None));
+                using var imageStream1 = Utilities.GetStreamFromBeatmap(beatmapLevels[0]);
+                using var imageStream2 = Utilities.GetStreamFromBeatmap(beatmapLevels[1]);
+                using var imageStream3 = Utilities.GetStreamFromBeatmap(beatmapLevels[2]);
+                using var imageStream4 = Utilities.GetStreamFromBeatmap(beatmapLevels[3]);
                 using var coverStream = await ImageUtilities.GenerateCollage(imageStream1 ?? Stream.Null, imageStream2 ?? Stream.Null, imageStream3 ?? Stream.Null, imageStream4 ?? Stream.Null);
                 await coverStream.CopyToAsync(ms);
             }

--- a/BeatSaberPlaylistsLib.BeatSaber/Utilities.BeatSaber.cs
+++ b/BeatSaberPlaylistsLib.BeatSaber/Utilities.BeatSaber.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using IPA.Loader;
+using CustomPreviewBeatmapLevel = BeatSaber::CustomPreviewBeatmapLevel;
 using Graphics = System.Drawing.Graphics;
 
 namespace BeatSaberPlaylistsLib
@@ -83,13 +84,14 @@ namespace BeatSaberPlaylistsLib
         /// <summary>
         /// Gets a <see cref="Stream"/> from a <see cref="Sprite"/>
         /// </summary>
-        /// <param name="sprite"></param>
+        /// <param name="previewBeatmapLevel"></param>
         /// <returns></returns>
-        public static Stream? GetStreamFromSprite(Sprite sprite)
+        public static Stream? GetStreamFromBeatmap(BeatSaber.IPreviewBeatmapLevel? previewBeatmapLevel)
         {
-            if (sprite.texture.isReadable)
+            if (previewBeatmapLevel is CustomPreviewBeatmapLevel customPreviewBeatmapLevel)
             {
-                return new MemoryStream(sprite.texture.EncodeToPNG());
+                var fileName = customPreviewBeatmapLevel.standardLevelInfoSaveData.coverImageFilename;
+                return new FileStream(Path.Combine(customPreviewBeatmapLevel.customLevelPath, fileName), FileMode.Open, FileAccess.Read, FileShare.Read, 0x4096, true);
             }
             return GetDefaultImageStream();
         }

--- a/Shared/ImageUtilities.cs
+++ b/Shared/ImageUtilities.cs
@@ -25,11 +25,12 @@ namespace BeatSaberPlaylistsLib
         public static async Task<Stream> GenerateCollage(Stream imageStream1, Stream imageStream2)
         {
             var image = new Image<Rgba32>(kImageSize, kImageSize);
-            using var image1 = await Image.LoadAsync(imageStream1);
-            using var image2 = await Image.LoadAsync(imageStream2);
-
-            await Task.Run(() =>
+            
+            await Task.Run(async () =>
             {
+                using var image1 = await Image.LoadAsync(imageStream1);
+                using var image2 = await Image.LoadAsync(imageStream2);
+                
                 image.Mutate(i =>
                 {
                     image1.Mutate(i1 =>
@@ -67,12 +68,13 @@ namespace BeatSaberPlaylistsLib
         public static async Task<Stream> GenerateCollage(Stream imageStream1, Stream imageStream2, Stream imageStream3)
         {
             var image = new Image<Rgba32>(kImageSize, kImageSize);
-            using var image1 = await Image.LoadAsync(imageStream1);
-            using var image2 = await Image.LoadAsync(imageStream2);
-            using var image3 = await Image.LoadAsync(imageStream3);
 
-            await Task.Run(() =>
+            await Task.Run(async () =>
             {
+                using var image1 = await Image.LoadAsync(imageStream1);
+                using var image2 = await Image.LoadAsync(imageStream2);
+                using var image3 = await Image.LoadAsync(imageStream3);
+                
                 image.Mutate(i =>
                 {
                     image1.Mutate(i1 =>
@@ -116,13 +118,14 @@ namespace BeatSaberPlaylistsLib
         public static async Task<Stream> GenerateCollage(Stream imageStream1, Stream imageStream2, Stream imageStream3, Stream imageStream4)
         {
             var image = new Image<Rgba32>(kImageSize, kImageSize);
-            using var image1 = await Image.LoadAsync(imageStream1);
-            using var image2 = await Image.LoadAsync(imageStream2);
-            using var image3 = await Image.LoadAsync(imageStream3);
-            using var image4 = await Image.LoadAsync(imageStream4);
 
-            await Task.Run(() =>
+            await Task.Run(async () =>
             {
+                using var image1 = await Image.LoadAsync(imageStream1);
+                using var image2 = await Image.LoadAsync(imageStream2);
+                using var image3 = await Image.LoadAsync(imageStream3);
+                using var image4 = await Image.LoadAsync(imageStream4);
+                
                 image.Mutate(i =>
                 {
                     image1.Mutate(i1 =>


### PR DESCRIPTION
For level covers, instead of reading from a sprite, the images are loaded directly and asynchronously