### PR TITLE
Handle / sanitize null playlistTitle

### DIFF
--- a/Shared/Blist/BlistPlaylist.cs
+++ b/Shared/Blist/BlistPlaylist.cs
@@ -43,7 +43,7 @@ namespace BeatSaberPlaylistsLib.Blist
         /// <summary>
         /// The playlist title
         /// </summary>
-        [JsonProperty("title", Order = -10)]
+        [JsonProperty("title", Order = -10, NullValueHandling = NullValueHandling.Ignore)]
         public override string Title { get; set; } = "";
 
         /// <summary>

--- a/Shared/Legacy/LegacyPlaylist.cs
+++ b/Shared/Legacy/LegacyPlaylist.cs
@@ -97,7 +97,7 @@ namespace BeatSaberPlaylistsLib.Legacy
 
         ///<inheritdoc/>
         [DataMember]
-        [JsonProperty("playlistTitle", Order = -10)]
+        [JsonProperty("playlistTitle", Order = -10, NullValueHandling = NullValueHandling.Ignore)]
         public override string Title { get; set; } = string.Empty;
         ///<inheritdoc/>
         [DataMember]


### PR DESCRIPTION
When the playlistTitle is null, it will load fine at first, but any plugin that tries to retrieve the packName, etc, will end up throwing because null gets passed to the Regexp